### PR TITLE
Added 'all' method to access all params

### DIFF
--- a/src/multipart.lua
+++ b/src/multipart.lua
@@ -115,6 +115,16 @@ function MultipartData:get(name)
   return self._data.data[self._data.indexes[name]]
 end
 
+function MultipartData:all() 
+  local results = {}
+  for _, v in ipairs(self._data.data) do
+    if v.value then
+      results[v.name] = v.value
+    end
+  end
+  return results
+end
+
 function MultipartData:set_simple(name, value)
   self._data.data[table_size(self._data.indexes) + 1] = {
     name = name,


### PR DESCRIPTION
This commit adds a new 'all' method that allows the user to get the complete list of parameters as a Lua table in order iterate over them. This is especially useful in order, for example, to convert multipart to query arguments.
